### PR TITLE
Create ATA account instruction in swap() if it does not exist

### DIFF
--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -11,13 +11,13 @@ import {
   U64Utils,
   PoolTokenCount,
   getTokenCount,
-  resolveAssociatedTokenAddress,
   TransactionBuilder,
   OrcaPool,
   OrcaToken,
   Quote,
   TransactionPayload,
   Percentage,
+  resolveOrCreateAssociatedTokenAddress,
 } from "../../../public";
 import {
   createApprovalInstruction,
@@ -136,16 +136,16 @@ export class OrcaPoolImpl implements OrcaPool {
     );
 
     const { address: inputPoolTokenUserAddress, ...resolveInputAddrInstructions } =
-      await resolveAssociatedTokenAddress(
+      await resolveOrCreateAssociatedTokenAddress(
         this.connection,
-        owner.publicKey,
+        owner,
         inputPoolToken.mint,
         amountInU64
       );
     const { address: outputPoolTokenUserAddress, ...resolveOutputAddrInstructions } =
-      await resolveAssociatedTokenAddress(
+      await resolveOrCreateAssociatedTokenAddress(
         this.connection,
-        owner.publicKey,
+        owner,
         outputPoolToken.mint,
         amountInU64
       );

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -53,7 +53,7 @@ export type OrcaPool = {
    * Fee for the transaction will be paid by the owner's wallet.
    *
    * NOTE:
-   * 1. User has to ensure that their owner address has established spl-token accounts for the trading pair.
+   * 1. Associated Token Address initialization instructions will be appended if the ATA of the specified token does not exist in the user's wallet
    * 2. OrcaU64 must have the same scale as the corresponding token scale value
    *
    * @param owner The keypair for the user's wallet

--- a/src/public/utils/models/instruction.ts
+++ b/src/public/utils/models/instruction.ts
@@ -6,6 +6,12 @@ import {
   TransactionSignature,
 } from "@solana/web3.js";
 
+export const emptyInstruction: Instruction = {
+  instructions: [],
+  cleanupInstructions: [],
+  signers: [],
+};
+
 export type Instruction = {
   instructions: TransactionInstruction[];
   cleanupInstructions: TransactionInstruction[];

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -1,24 +1,46 @@
 import { AccountLayout, TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
-import { Connection, PublicKey, Signer, TransactionInstruction } from "@solana/web3.js";
-import { Instruction } from "..";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import { solToken } from "../../../constants/pools";
 import { SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID } from "../constants";
-import { createWSOLAccountInstructions } from "./instructions/token-instructions";
+import { emptyInstruction, Instruction } from "../models/instruction";
+import { deserializeAccount } from "./deserialize-account";
+import {
+  createAssociatedTokenAccountInstruction,
+  createWSOLAccountInstructions,
+} from "./instructions/token-instructions";
 
 export type ResolvedTokenAddressInstruction = { address: PublicKey } & Instruction;
 
-export async function resolveAssociatedTokenAddress(
+export async function resolveOrCreateAssociatedTokenAddress(
   connection: Connection,
-  walletAddress: PublicKey,
+  owner: Keypair,
   tokenMint: PublicKey,
   amountIn = new u64(0)
 ): Promise<ResolvedTokenAddressInstruction> {
   if (tokenMint !== solToken.mint) {
+    const derivedAddress = await deriveAssociatedTokenAddress(owner.publicKey, tokenMint);
+
+    // Check if current wallet has an ATA for this spl-token mint. If not, create one.
+    let resolveAtaInstruction = emptyInstruction;
+    await connection.getAccountInfo(derivedAddress).then((info) => {
+      const tokenAccountInfo = deserializeAccount(info?.data);
+
+      if (!tokenAccountInfo) {
+        resolveAtaInstruction = createAssociatedTokenAccountInstruction(
+          derivedAddress,
+          owner.publicKey,
+          owner.publicKey,
+          tokenMint,
+          owner
+        );
+      }
+    });
+
     return {
-      address: await deriveAssociatedTokenAddress(walletAddress, tokenMint),
-      instructions: [],
-      cleanupInstructions: [],
-      signers: [],
+      address: derivedAddress,
+      instructions: resolveAtaInstruction.instructions,
+      cleanupInstructions: resolveAtaInstruction.cleanupInstructions,
+      signers: resolveAtaInstruction.signers,
     };
   } else {
     // TODO: Is there a way to store this cleaner?
@@ -26,7 +48,12 @@ export async function resolveAssociatedTokenAddress(
       AccountLayout.span
     );
     // Create a temp-account to transfer SOL in the form of WSOL
-    return createWSOLAccountInstructions(walletAddress, solToken.mint, amountIn, accountRentExempt);
+    return createWSOLAccountInstructions(
+      owner.publicKey,
+      solToken.mint,
+      amountIn,
+      accountRentExempt
+    );
   }
 }
 

--- a/src/public/utils/web3/instructions/token-instructions.ts
+++ b/src/public/utils/web3/instructions/token-instructions.ts
@@ -1,5 +1,12 @@
 import { AccountLayout, Token, TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
-import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { Instruction, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID } from "../..";
 import { ResolvedTokenAddressInstruction } from "../ata-utils";
 
 export const createWSOLAccountInstructions = (
@@ -40,3 +47,60 @@ export const createWSOLAccountInstructions = (
     signers: [tempAccount],
   };
 };
+
+export function createAssociatedTokenAccountInstruction(
+  associatedTokenAddress: PublicKey,
+  fundSource: PublicKey,
+  destination: PublicKey,
+  tokenMint: PublicKey,
+  fundAddressOwner: Keypair
+): Instruction {
+  const systemProgramId = new PublicKey("11111111111111111111111111111111");
+  const keys = [
+    {
+      pubkey: fundSource,
+      isSigner: true,
+      isWritable: true,
+    },
+    {
+      pubkey: associatedTokenAddress,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: destination,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: tokenMint,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: systemProgramId,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: TOKEN_PROGRAM_ID,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SYSVAR_RENT_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+  const createATAInstruction = new TransactionInstruction({
+    keys,
+    programId: SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
+    data: Buffer.from([]),
+  });
+  return {
+    instructions: [createATAInstruction],
+    cleanupInstructions: [],
+    signers: [fundAddressOwner],
+  };
+}


### PR DESCRIPTION
- If the user's wallet does not have the AT address for the input/output
  token, append the instruction to initialize it.


Note: This change adds 1 extra rpc call to the swap() call. We'll address this on future iterations where we build APIs to allow caching of the token ATA statuses. 

### [Test]
- On a new wallet with no spl-tokens, attempted to transfer 1 token B -> A. Instructions to init both tokens are pushed into the tx
- On a wallet with token B but not tokenA, confirmed that token A instructions went through and successfully created the wallet before depositing it
- On a wallet where both exists, no regression