### PR TITLE
Support wallet signing for swap

### DIFF
--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -127,7 +127,7 @@ export class OrcaPoolImpl implements OrcaPool {
   ): Promise<O extends Keypair ? ExecutableTransactionPayload : TransactionPayload> {
     const _owner = new Owner(owner);
 
-    const ownerAddress = _owner.getPublicKey();
+    const ownerAddress = _owner.publicKey;
 
     const { inputPoolToken, outputPoolToken } = getTokens(
       this.poolParams,

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -177,7 +177,7 @@ export class OrcaPoolImpl implements OrcaPool {
       userTransferAuthority.publicKey
     );
 
-    return await new TransactionBuilder(this.connection, ownerAddress, owner)
+    return await new TransactionBuilder(this.connection, ownerAddress, _owner)
       .addInstruction(resolveInputAddrInstructions)
       .addInstruction(resolveOutputAddrInstructions)
       .addInstruction(approvalInstruction)

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -118,12 +118,12 @@ export class OrcaPoolImpl implements OrcaPool {
     return quote;
   }
 
-  public async swap<O extends Keypair | PublicKey>(
-    owner: O,
+  public async swap(
+    owner: Keypair | PublicKey,
     inputToken: OrcaToken,
     amountIn: Decimal | OrcaU64,
     minimumAmountOut: Decimal | OrcaU64
-  ): Promise<TransactionPayload<O>> {
+  ): Promise<TransactionPayload> {
     const _owner = new Owner(owner);
 
     const ownerAddress = _owner.publicKey;

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -18,7 +18,6 @@ import {
   TransactionPayload,
   Percentage,
   resolveOrCreateAssociatedTokenAddress,
-  ExecutableTransactionPayload,
 } from "../../../public";
 import {
   createApprovalInstruction,
@@ -124,7 +123,7 @@ export class OrcaPoolImpl implements OrcaPool {
     inputToken: OrcaToken,
     amountIn: Decimal | OrcaU64,
     minimumAmountOut: Decimal | OrcaU64
-  ): Promise<O extends Keypair ? ExecutableTransactionPayload : TransactionPayload> {
+  ): Promise<TransactionPayload<O>> {
     const _owner = new Owner(owner);
 
     const ownerAddress = _owner.publicKey;
@@ -178,11 +177,11 @@ export class OrcaPoolImpl implements OrcaPool {
       userTransferAuthority.publicKey
     );
 
-    return (await new TransactionBuilder(this.connection, ownerAddress)
+    return await new TransactionBuilder(this.connection, ownerAddress, owner)
       .addInstruction(resolveInputAddrInstructions)
       .addInstruction(resolveOutputAddrInstructions)
       .addInstruction(approvalInstruction)
       .addInstruction(swapInstruction)
-      .build()) as O extends Keypair ? ExecutableTransactionPayload : TransactionPayload;
+      .build();
   }
 }

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -62,12 +62,12 @@ export type OrcaPool = {
    * @param minimumAmountOut The minimum amount of outputToken to receive from this swap
    * @return The transaction signature of the swap instruction
    */
-  swap: <O extends Keypair | PublicKey>(
-    owner: O,
+  swap: (
+    owner: Keypair | PublicKey,
     inputToken: OrcaToken,
     amountIn: Decimal | OrcaU64,
     minimumAmountOut: Decimal | OrcaU64
-  ) => Promise<TransactionPayload<O>>;
+  ) => Promise<TransactionPayload>;
 };
 
 /**

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -1,7 +1,7 @@
 import { Keypair, PublicKey, TransactionSignature } from "@solana/web3.js";
 import Decimal from "decimal.js";
 import { OrcaU64 } from "..";
-import { ExecutableTransactionPayload, TransactionPayload } from "../utils";
+import { TransactionPayload } from "../utils";
 
 /**
  * Allows interactions with an Orca liquidity pool.
@@ -67,7 +67,7 @@ export type OrcaPool = {
     inputToken: OrcaToken,
     amountIn: Decimal | OrcaU64,
     minimumAmountOut: Decimal | OrcaU64
-  ) => Promise<O extends Keypair ? ExecutableTransactionPayload : TransactionPayload>;
+  ) => Promise<TransactionPayload<O>>;
 };
 
 /**

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -1,7 +1,7 @@
 import { Keypair, PublicKey, TransactionSignature } from "@solana/web3.js";
 import Decimal from "decimal.js";
 import { OrcaU64 } from "..";
-import { TransactionPayload } from "../utils";
+import { ExecutableTransactionPayload, TransactionPayload } from "../utils";
 
 /**
  * Allows interactions with an Orca liquidity pool.
@@ -56,18 +56,18 @@ export type OrcaPool = {
    * 1. Associated Token Address initialization instructions will be appended if the ATA of the specified token does not exist in the user's wallet
    * 2. OrcaU64 must have the same scale as the corresponding token scale value
    *
-   * @param owner The keypair for the user's wallet
+   * @param owner The keypair for the user's wallet or just the user's public key
    * @param inputToken An Orca supported token in the user's wallet to swap from
    * @param amountIn The amount of inputToken to swap from
    * @param minimumAmountOut The minimum amount of outputToken to receive from this swap
    * @return The transaction signature of the swap instruction
    */
-  swap: (
-    owner: Keypair,
+  swap: <O extends Keypair | PublicKey>(
+    owner: O,
     inputToken: OrcaToken,
     amountIn: Decimal | OrcaU64,
     minimumAmountOut: Decimal | OrcaU64
-  ) => Promise<TransactionPayload>;
+  ) => Promise<O extends Keypair ? ExecutableTransactionPayload : TransactionPayload>;
 };
 
 /**

--- a/src/public/utils/models/instruction.ts
+++ b/src/public/utils/models/instruction.ts
@@ -19,8 +19,8 @@ export type Instruction = {
   signers: Signer[];
 };
 
-export type TransactionPayload<Owner extends Keypair | PublicKey> = {
+export type TransactionPayload = {
   transaction: Transaction;
   signers: Signer[];
-  execute: Owner extends Keypair ? () => Promise<TransactionSignature> : undefined;
+  execute: () => Promise<TransactionSignature>;
 };

--- a/src/public/utils/models/instruction.ts
+++ b/src/public/utils/models/instruction.ts
@@ -1,5 +1,6 @@
 import {
   Keypair,
+  PublicKey,
   Signer,
   Transaction,
   TransactionInstruction,
@@ -15,11 +16,16 @@ export const emptyInstruction: Instruction = {
 export type Instruction = {
   instructions: TransactionInstruction[];
   cleanupInstructions: TransactionInstruction[];
-  signers: Keypair[];
+  signers: (Keypair | PublicKey)[];
+};
+
+export type ExecutableTransactionPayload = {
+  transaction: Transaction;
+  signers: Signer[];
+  execute: () => Promise<TransactionSignature>;
 };
 
 export type TransactionPayload = {
   transaction: Transaction;
-  signers: Signer[];
-  execute: () => Promise<TransactionSignature>;
+  signers: (Keypair | PublicKey)[];
 };

--- a/src/public/utils/models/instruction.ts
+++ b/src/public/utils/models/instruction.ts
@@ -16,16 +16,11 @@ export const emptyInstruction: Instruction = {
 export type Instruction = {
   instructions: TransactionInstruction[];
   cleanupInstructions: TransactionInstruction[];
-  signers: (Keypair | PublicKey)[];
+  signers: Signer[];
 };
 
-export type ExecutableTransactionPayload = {
+export type TransactionPayload<Owner extends Keypair | PublicKey> = {
   transaction: Transaction;
   signers: Signer[];
-  execute: () => Promise<TransactionSignature>;
-};
-
-export type TransactionPayload = {
-  transaction: Transaction;
-  signers: (Keypair | PublicKey)[];
+  execute: Owner extends Keypair ? () => Promise<TransactionSignature> : undefined;
 };

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -8,17 +8,18 @@ import {
   createAssociatedTokenAccountInstruction,
   createWSOLAccountInstructions,
 } from "./instructions/token-instructions";
+import { Owner } from "./key-utils";
 
 export type ResolvedTokenAddressInstruction = { address: PublicKey } & Instruction;
 
 export async function resolveOrCreateAssociatedTokenAddress(
   connection: Connection,
-  owner: Keypair,
+  owner: Owner,
   tokenMint: PublicKey,
   amountIn = new u64(0)
 ): Promise<ResolvedTokenAddressInstruction> {
   if (tokenMint !== solToken.mint) {
-    const derivedAddress = await deriveAssociatedTokenAddress(owner.publicKey, tokenMint);
+    const derivedAddress = await deriveAssociatedTokenAddress(owner.getPublicKey(), tokenMint);
 
     // Check if current wallet has an ATA for this spl-token mint. If not, create one.
     let resolveAtaInstruction = emptyInstruction;
@@ -28,8 +29,8 @@ export async function resolveOrCreateAssociatedTokenAddress(
       if (!tokenAccountInfo) {
         resolveAtaInstruction = createAssociatedTokenAccountInstruction(
           derivedAddress,
-          owner.publicKey,
-          owner.publicKey,
+          owner.getPublicKey(),
+          owner.getPublicKey(),
           tokenMint,
           owner
         );
@@ -49,7 +50,7 @@ export async function resolveOrCreateAssociatedTokenAddress(
     );
     // Create a temp-account to transfer SOL in the form of WSOL
     return createWSOLAccountInstructions(
-      owner.publicKey,
+      owner.getPublicKey(),
       solToken.mint,
       amountIn,
       accountRentExempt

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -19,7 +19,7 @@ export async function resolveOrCreateAssociatedTokenAddress(
   amountIn = new u64(0)
 ): Promise<ResolvedTokenAddressInstruction> {
   if (tokenMint !== solToken.mint) {
-    const derivedAddress = await deriveAssociatedTokenAddress(owner.getPublicKey(), tokenMint);
+    const derivedAddress = await deriveAssociatedTokenAddress(owner.publicKey, tokenMint);
 
     // Check if current wallet has an ATA for this spl-token mint. If not, create one.
     let resolveAtaInstruction = emptyInstruction;
@@ -29,8 +29,8 @@ export async function resolveOrCreateAssociatedTokenAddress(
       if (!tokenAccountInfo) {
         resolveAtaInstruction = createAssociatedTokenAccountInstruction(
           derivedAddress,
-          owner.getPublicKey(),
-          owner.getPublicKey(),
+          owner.publicKey,
+          owner.publicKey,
           tokenMint,
           owner
         );
@@ -50,7 +50,7 @@ export async function resolveOrCreateAssociatedTokenAddress(
     );
     // Create a temp-account to transfer SOL in the form of WSOL
     return createWSOLAccountInstructions(
-      owner.getPublicKey(),
+      owner.publicKey,
       solToken.mint,
       amountIn,
       accountRentExempt

--- a/src/public/utils/web3/instructions/pool-instructions.ts
+++ b/src/public/utils/web3/instructions/pool-instructions.ts
@@ -76,6 +76,6 @@ export const createSwapInstruction = async (
   return {
     instructions: [swapInstruction],
     cleanupInstructions: [],
-    signers: [owner.getSigner()],
+    signers: [owner.signer],
   };
 };

--- a/src/public/utils/web3/instructions/pool-instructions.ts
+++ b/src/public/utils/web3/instructions/pool-instructions.ts
@@ -4,6 +4,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import { OrcaPoolParams, OrcaPoolToken } from "../../../../model/orca/pool/pool-types";
 import { ORCA_TOKEN_SWAP_ID } from "../../constants";
 import { Instruction } from "../../models";
+import { Owner } from "../key-utils";
 
 export const createApprovalInstruction = (
   ownerAddress: PublicKey,
@@ -38,7 +39,7 @@ export const createApprovalInstruction = (
 
 export const createSwapInstruction = async (
   poolParams: OrcaPoolParams,
-  owner: Keypair,
+  owner: Owner,
   inputToken: OrcaPoolToken,
   inputTokenUserAddress: PublicKey,
   outputToken: OrcaPoolToken,
@@ -75,6 +76,6 @@ export const createSwapInstruction = async (
   return {
     instructions: [swapInstruction],
     cleanupInstructions: [],
-    signers: [owner],
+    signers: [owner.getSigner()],
   };
 };

--- a/src/public/utils/web3/instructions/pool-instructions.ts
+++ b/src/public/utils/web3/instructions/pool-instructions.ts
@@ -76,6 +76,6 @@ export const createSwapInstruction = async (
   return {
     instructions: [swapInstruction],
     cleanupInstructions: [],
-    signers: [owner.signer],
+    signers: owner.signer ? [owner.signer] : [],
   };
 };

--- a/src/public/utils/web3/instructions/token-instructions.ts
+++ b/src/public/utils/web3/instructions/token-instructions.ts
@@ -102,6 +102,6 @@ export function createAssociatedTokenAccountInstruction(
   return {
     instructions: [createATAInstruction],
     cleanupInstructions: [],
-    signers: [fundAddressOwner.signer],
+    signers: fundAddressOwner.signer ? [fundAddressOwner.signer] : [],
   };
 }

--- a/src/public/utils/web3/instructions/token-instructions.ts
+++ b/src/public/utils/web3/instructions/token-instructions.ts
@@ -8,6 +8,7 @@ import {
 } from "@solana/web3.js";
 import { Instruction, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID } from "../..";
 import { ResolvedTokenAddressInstruction } from "../ata-utils";
+import { Owner } from "../key-utils";
 
 export const createWSOLAccountInstructions = (
   owner: PublicKey,
@@ -53,7 +54,7 @@ export function createAssociatedTokenAccountInstruction(
   fundSource: PublicKey,
   destination: PublicKey,
   tokenMint: PublicKey,
-  fundAddressOwner: Keypair
+  fundAddressOwner: Owner
 ): Instruction {
   const systemProgramId = new PublicKey("11111111111111111111111111111111");
   const keys = [
@@ -101,6 +102,6 @@ export function createAssociatedTokenAccountInstruction(
   return {
     instructions: [createATAInstruction],
     cleanupInstructions: [],
-    signers: [fundAddressOwner],
+    signers: [fundAddressOwner.getSigner()],
   };
 }

--- a/src/public/utils/web3/instructions/token-instructions.ts
+++ b/src/public/utils/web3/instructions/token-instructions.ts
@@ -102,6 +102,6 @@ export function createAssociatedTokenAccountInstruction(
   return {
     instructions: [createATAInstruction],
     cleanupInstructions: [],
-    signers: [fundAddressOwner.getSigner()],
+    signers: [fundAddressOwner.signer],
   };
 }

--- a/src/public/utils/web3/key-utils.ts
+++ b/src/public/utils/web3/key-utils.ts
@@ -17,8 +17,8 @@ export class Owner {
     return this._owner;
   }
 
-  get signer(): Keypair | PublicKey {
-    return this._owner;
+  get signer(): Signer | undefined {
+    return Owner.isKeyPair(this._owner) ? this._owner : undefined;
   }
 
   static isKeyPair(owner: _Owner): owner is Keypair {
@@ -26,7 +26,7 @@ export class Owner {
   }
 
   static isPublicKey(owner: _Owner): owner is PublicKey {
-    return !Owner.isPublicKey(owner);
+    return !Owner.isKeyPair(owner);
   }
 }
 

--- a/src/public/utils/web3/key-utils.ts
+++ b/src/public/utils/web3/key-utils.ts
@@ -9,7 +9,7 @@ export class Owner {
     this._owner = owner;
   }
 
-  getPublicKey(): PublicKey {
+  get publicKey(): PublicKey {
     if (Owner.isKeyPair(this._owner)) {
       return this._owner.publicKey;
     }
@@ -17,7 +17,7 @@ export class Owner {
     return this._owner;
   }
 
-  getSigner(): Keypair | PublicKey {
+  get signer(): Keypair | PublicKey {
     return this._owner;
   }
 

--- a/src/public/utils/web3/key-utils.ts
+++ b/src/public/utils/web3/key-utils.ts
@@ -21,6 +21,14 @@ export class Owner {
     return Owner.isKeyPair(this._owner) ? this._owner : undefined;
   }
 
+  get isKeyPair(): boolean {
+    return Owner.isKeyPair(this._owner);
+  }
+
+  get isPublicKey(): boolean {
+    return Owner.isPublicKey(this._owner);
+  }
+
   static isKeyPair(owner: _Owner): owner is Keypair {
     return (owner as Keypair).secretKey !== undefined;
   }

--- a/src/public/utils/web3/key-utils.ts
+++ b/src/public/utils/web3/key-utils.ts
@@ -1,0 +1,39 @@
+import { Keypair, PublicKey, Signer } from "@solana/web3.js";
+
+type _Owner = Keypair | PublicKey;
+
+export class Owner {
+  private readonly _owner: _Owner;
+
+  constructor(owner: _Owner) {
+    this._owner = owner;
+  }
+
+  getPublicKey(): PublicKey {
+    if (Owner.isKeyPair(this._owner)) {
+      return this._owner.publicKey;
+    }
+
+    return this._owner;
+  }
+
+  getSigner(): Keypair | PublicKey {
+    return this._owner;
+  }
+
+  static isKeyPair(owner: _Owner): owner is Keypair {
+    return (owner as Keypair).secretKey !== undefined;
+  }
+
+  static isPublicKey(owner: _Owner): owner is PublicKey {
+    return !Owner.isPublicKey(owner);
+  }
+}
+
+export function onlyKeyPairs(owners: _Owner[]): owners is Keypair[] {
+  return !owners.some(Owner.isPublicKey);
+}
+
+export function onlyPublicKeys(owners: _Owner[]): owners is PublicKey[] {
+  return !owners.some(Owner.isKeyPair);
+}

--- a/src/public/utils/web3/key-utils.ts
+++ b/src/public/utils/web3/key-utils.ts
@@ -29,11 +29,3 @@ export class Owner {
     return !Owner.isKeyPair(owner);
   }
 }
-
-export function onlyKeyPairs(owners: _Owner[]): owners is Keypair[] {
-  return !owners.some(Owner.isPublicKey);
-}
-
-export function onlyPublicKeys(owners: _Owner[]): owners is PublicKey[] {
-  return !owners.some(Owner.isKeyPair);
-}

--- a/src/public/utils/web3/transactions/transaction-builder.ts
+++ b/src/public/utils/web3/transactions/transaction-builder.ts
@@ -1,33 +1,36 @@
 import {
   Connection,
-  Keypair,
   PublicKey,
   sendAndConfirmTransaction,
   Transaction,
   TransactionCtorFields,
+  Signer,
+  Keypair,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { Instruction, TransactionPayload } from "../..";
-import { ExecutableTransactionPayload } from "../../models";
-import { onlyKeyPairs, Owner } from "../key-utils";
+import { Instruction } from "../..";
+import { TransactionPayload } from "../../models";
+import { Owner } from "../key-utils";
 
-export class TransactionBuilder {
+export class TransactionBuilder<Owner extends Keypair | PublicKey> {
   private connection: Connection;
   private feePayer: PublicKey;
   private instructions: Instruction[];
+  private owner: Owner;
 
-  constructor(connection: Connection, feePayer: PublicKey) {
+  constructor(connection: Connection, feePayer: PublicKey, owner: Owner) {
     this.connection = connection;
     this.feePayer = feePayer;
     this.instructions = [];
+    this.owner = owner;
   }
 
-  addInstruction(instruction: Instruction): TransactionBuilder {
+  addInstruction(instruction: Instruction): TransactionBuilder<Owner> {
     this.instructions.push(instruction);
     return this;
   }
 
-  async build() {
+  async build(): Promise<TransactionPayload<Owner>> {
     const recentBlockHash = (await this.connection.getRecentBlockhash("singleGossip")).blockhash;
     const txFields: TransactionCtorFields = {
       recentBlockhash: recentBlockHash,
@@ -36,7 +39,7 @@ export class TransactionBuilder {
 
     let instructions: TransactionInstruction[] = [];
     let cleanupInstructions: TransactionInstruction[] = [];
-    let signers: (Keypair | PublicKey)[] = [];
+    let signers: Signer[] = [];
     this.instructions.forEach((curr) => {
       instructions = instructions.concat(curr.instructions);
       cleanupInstructions = cleanupInstructions.concat(curr.cleanupInstructions);
@@ -47,19 +50,14 @@ export class TransactionBuilder {
     transaction.add(...instructions.concat(cleanupInstructions));
     transaction.feePayer = this.feePayer;
 
-    if (onlyKeyPairs(signers)) {
-      return {
-        transaction: transaction,
-        signers: signers as Keypair[],
-        execute: async () => {
-          return sendAndConfirmTransaction(this.connection, transaction, signers as Keypair[]);
-        },
-      } as ExecutableTransactionPayload;
-    } else {
-      return {
-        transaction: transaction,
-        signers: signers,
-      } as TransactionPayload;
-    }
+    return {
+      transaction: transaction,
+      signers: signers,
+      execute: Owner.isKeyPair(this.owner)
+        ? async () => {
+            return sendAndConfirmTransaction(this.connection, transaction, signers);
+          }
+        : undefined,
+    } as TransactionPayload<Owner>;
   }
 }

--- a/src/public/utils/web3/transactions/transaction-builder.ts
+++ b/src/public/utils/web3/transactions/transaction-builder.ts
@@ -30,7 +30,7 @@ export class TransactionBuilder<Owner extends Keypair | PublicKey> {
     return this;
   }
 
-  async build(): Promise<TransactionPayload<Owner>> {
+  async build(): Promise<TransactionPayload> {
     const recentBlockHash = (await this.connection.getRecentBlockhash("singleGossip")).blockhash;
     const txFields: TransactionCtorFields = {
       recentBlockhash: recentBlockHash,
@@ -57,7 +57,9 @@ export class TransactionBuilder<Owner extends Keypair | PublicKey> {
         ? async () => {
             return sendAndConfirmTransaction(this.connection, transaction, signers);
           }
-        : undefined,
-    } as TransactionPayload<Owner>;
+        : async () => {
+            throw new Error("Public key based swap does not support transaction execution");
+          },
+    };
   }
 }

--- a/src/public/utils/web3/transactions/transaction-builder.ts
+++ b/src/public/utils/web3/transactions/transaction-builder.ts
@@ -12,7 +12,7 @@ import { Instruction } from "../..";
 import { TransactionPayload } from "../../models";
 import { Owner } from "../key-utils";
 
-export class TransactionBuilder<Owner extends Keypair | PublicKey> {
+export class TransactionBuilder {
   private connection: Connection;
   private feePayer: PublicKey;
   private instructions: Instruction[];
@@ -25,7 +25,7 @@ export class TransactionBuilder<Owner extends Keypair | PublicKey> {
     this.owner = owner;
   }
 
-  addInstruction(instruction: Instruction): TransactionBuilder<Owner> {
+  addInstruction(instruction: Instruction): TransactionBuilder {
     this.instructions.push(instruction);
     return this;
   }
@@ -53,12 +53,14 @@ export class TransactionBuilder<Owner extends Keypair | PublicKey> {
     return {
       transaction: transaction,
       signers: signers,
-      execute: Owner.isKeyPair(this.owner)
+      execute: this.owner.isKeyPair
         ? async () => {
             return sendAndConfirmTransaction(this.connection, transaction, signers);
           }
         : async () => {
-            throw new Error("Public key based swap does not support transaction execution");
+            throw new Error(
+              "Please use a Keypair for the owner parameter to enable the execute function"
+            );
           },
     };
   }


### PR DESCRIPTION
**Background:** 

Currently, the SDK only supports CLI wallets. CLI can generate a Keypair object (public + private key) & the swap() functionality currently supports signing by providing the Keypair object. 

We want to add support for the browser-use case as well - instead of passing in a Keypair object, users of the SDK has to let their version of the Wallet object to sign it. 

**Accceptance Criteria:**
- [x] Instead of passing in a Keypair object for swap, provide the option to pass in a public key
- [x] If the user passed in a publickey, then the TransactionPayload returned here should return an empty "execute" object. 

**TODOs:**
- [x] Test e2e

**Testing methodology**

Used the wallet object on our app to simulate a USDC -> SOL swap. Code used for this:

```typescript
export async function getConnection(url: string = "https://orca.rpcpool.com/"): Promise<Connection> {
  const connection = new Connection(url, "singleGossip");
  const version = await connection.getVersion();

  console.log("Connection to cluster established:", url, version);
  return connection;
}

export async function swap(wallet: Wallet | null): Promise<void> {
  if (!wallet) {
    throw new Error('wallet was null');
  }

  const connection = await getConnection();
  const orca = getOrca(connection);

  try {
    const pool = orca.getPool(OrcaPoolConfig.SOL_USDC);
    const token = pool.getTokenB();
    const tradeValue = new Decimal(0.1);
    const quote = await pool.getQuote(token, tradeValue, new Decimal(0.1));

    const swapInstructions = await pool.swap(wallet.publicKey(), token, tradeValue, quote.getMinOutputAmount())
    swapInstructions.transaction.partialSign(...swapInstructions.signers);
    const signedTransaction = await wallet.signTransaction(swapInstructions.transaction);
    await sendAndConfirm(connection, signedTransaction)();
  } catch (err) {
    console.error(err);
  }
}
```