### PR TITLE
Fix: no longer create wsol account when SOL is destination

### DIFF
--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -204,7 +204,7 @@ export class OrcaPoolImpl implements OrcaPool {
       "poolTokenAmount"
     );
 
-    // If tokenA is SOL, this will create a new wSOL account
+    // If tokenA is SOL, this will create a new wSOL account with maxTokenAIn_U64
     // Otherwise, get tokenA's associated token account
     const { address: userTokenAPublicKey, ...resolveTokenAInstrucitons } =
       await resolveOrCreateAssociatedTokenAddress(
@@ -214,7 +214,7 @@ export class OrcaPoolImpl implements OrcaPool {
         maxTokenAIn_U64
       );
 
-    // If tokenB is SOL, this won't do anything because we don't need WSOL as destination
+    // If tokenB is SOL, this will create a new wSOL account
     // Otherwise, get tokenB's associated token account
     const { address: userTokenBPublicKey, ...resolveTokenBInstrucitons } =
       await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, tokenB.mint);

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -152,12 +152,7 @@ export class OrcaPoolImpl implements OrcaPool {
       );
 
     const { address: outputPoolTokenUserAddress, ...resolveOutputAddrInstructions } =
-      await resolveOrCreateAssociatedTokenAddress(
-        this.connection,
-        _owner,
-        outputPoolToken.mint,
-        amountInU64
-      );
+      await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, outputPoolToken.mint);
 
     if (inputPoolTokenUserAddress === undefined || outputPoolTokenUserAddress === undefined) {
       throw new Error("Unable to derive input / output token associated address.");
@@ -219,15 +214,10 @@ export class OrcaPoolImpl implements OrcaPool {
         maxTokenAIn_U64
       );
 
-    // If tokenB is SOL, this will create a new wSOL account
+    // If tokenB is SOL, this won't do anything because we don't need WSOL as destination
     // Otherwise, get tokenB's associated token account
     const { address: userTokenBPublicKey, ...resolveTokenBInstrucitons } =
-      await resolveOrCreateAssociatedTokenAddress(
-        this.connection,
-        _owner,
-        tokenB.mint,
-        maxTokenBIn_U64
-      );
+      await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, tokenB.mint);
 
     // If the user lacks the pool token account, create it
     const { address: userPoolTokenPublicKey, ...resolvePoolTokenInstructions } =
@@ -297,21 +287,11 @@ export class OrcaPoolImpl implements OrcaPool {
 
     // Create a token account for tokenA, if necessary
     const { address: userTokenAPublicKey, ...resolveTokenAInstrucitons } =
-      await resolveOrCreateAssociatedTokenAddress(
-        this.connection,
-        _owner,
-        tokenA.mint,
-        minTokenAOut_U64
-      );
+      await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, tokenA.mint);
 
     // Create a token account for tokenB, if necessary
     const { address: userTokenBPublicKey, ...resolveTokenBInstrucitons } =
-      await resolveOrCreateAssociatedTokenAddress(
-        this.connection,
-        _owner,
-        tokenB.mint,
-        minTokenBOut_U64
-      );
+      await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, tokenB.mint);
 
     // Get user's poolToken token account
     const { address: userPoolTokenPublicKey, ...resolvePoolTokenInstructions } =

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -214,10 +214,15 @@ export class OrcaPoolImpl implements OrcaPool {
         maxTokenAIn_U64
       );
 
-    // If tokenB is SOL, this will create a new wSOL account
+    // If tokenB is SOL, this will create a new wSOL account with maxTokenBIn_U64
     // Otherwise, get tokenB's associated token account
     const { address: userTokenBPublicKey, ...resolveTokenBInstrucitons } =
-      await resolveOrCreateAssociatedTokenAddress(this.connection, _owner, tokenB.mint);
+      await resolveOrCreateAssociatedTokenAddress(
+        this.connection,
+        _owner,
+        tokenB.mint,
+        maxTokenBIn_U64
+      );
 
     // If the user lacks the pool token account, create it
     const { address: userPoolTokenPublicKey, ...resolvePoolTokenInstructions } =

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -14,8 +14,8 @@ export type ResolvedTokenAddressInstruction = { address: PublicKey } & Instructi
 
 /**
  * IMPORTANT: wrappedSolAmountIn should only be used for input/source token that
- *            could be SOL. This is because when SOL is output, it is the end
- *            destination, and thus does not need to be wrapped.
+ *            could be SOL. This is because when SOL is the output, it is the end
+ *            destination, and thus does not need to be wrapped with an amount.
  *
  * @param connection Solana connection class
  * @param owner The keypair for the user's wallet or just the user's public key

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -13,21 +13,21 @@ import { Owner } from "./key-utils";
 export type ResolvedTokenAddressInstruction = { address: PublicKey } & Instruction;
 
 /**
- * IMPORTANT: amountIn should only be used for input/source token that could be SOL.
- *            This is because when SOL is output, it is the end destination, and thus
- *            does not need to be wrapped.
+ * IMPORTANT: wrappedSolAmountIn should only be used for input/source token that
+ *            could be SOL. This is because when SOL is output, it is the end
+ *            destination, and thus does not need to be wrapped.
  *
  * @param connection Solana connection class
  * @param owner The keypair for the user's wallet or just the user's public key
  * @param tokenMint Token mint address
- * @param amountIn Optional. Only use for input/source token that could be SOL
+ * @param wrappedSolAmountIn Optional. Only use for input/source token that could be SOL
  * @returns
  */
 export async function resolveOrCreateAssociatedTokenAddress(
   connection: Connection,
   owner: Owner,
   tokenMint: PublicKey,
-  amountIn = new u64(0)
+  wrappedSolAmountIn = new u64(0)
 ): Promise<ResolvedTokenAddressInstruction> {
   if (tokenMint !== solToken.mint) {
     const derivedAddress = await deriveAssociatedTokenAddress(owner.publicKey, tokenMint);
@@ -63,7 +63,7 @@ export async function resolveOrCreateAssociatedTokenAddress(
     return createWSOLAccountInstructions(
       owner.publicKey,
       solToken.mint,
-      amountIn,
+      wrappedSolAmountIn,
       accountRentExempt
     );
   }

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -12,6 +12,17 @@ import { Owner } from "./key-utils";
 
 export type ResolvedTokenAddressInstruction = { address: PublicKey } & Instruction;
 
+/**
+ * IMPORTANT: amountIn should only be used for input/source token that could be SOL.
+ *            This is because when SOL is output, it is the end destination, and thus
+ *            does not need to be wrapped.
+ *
+ * @param connection Solana connection class
+ * @param owner The keypair for the user's wallet or just the user's public key
+ * @param tokenMint Token mint address
+ * @param amountIn Optional. Only use for input/source token that could be SOL
+ * @returns
+ */
 export async function resolveOrCreateAssociatedTokenAddress(
   connection: Connection,
   owner: Owner,


### PR DESCRIPTION
### Context

* User faced a bug, where they tried to swap tokenA -> SOL but the tx failed. The issue was that the swap method tried to create a wrapped SOL account with a value which happened to be larger than SOL they possessed. This shouldn't have happened. When SOL is the output of a swap (or withdraw for that matter), wrapped SOL account shouldn't be created with an amountIn.

### Notes

* Removed `amountInU64` from swap
* Removed `minTokenAOut_U64` and `minTokenBOut_U64` from withdraw
* Added cautionary comments to `resolveOrCreateAssociatedTokenAddress`

### Tests

* Reproduced the issue with STEP-SOL swap, because they have the same decimals (i.e. 9).
* Confirmed fix with this change.
* Same for withdraw. Saw the issue with STEP-SOL withdraw, and confirmed the this PR fixes it.
