### PR TITLE
Pool add getDepositQuote, getWithdrawQuote api's

### DIFF
--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -19,7 +19,6 @@ import {
   TransactionPayload,
   Percentage,
   resolveOrCreateAssociatedTokenAddress,
-  getSingleTokenCount,
   ZERO,
 } from "../../../public";
 import {

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -4,17 +4,17 @@ import { OrcaU64 } from "..";
 import { TransactionPayload } from "../utils";
 
 /* TokenInAmount types */
-export type TokenInAmount = PercentInAmount<"percent"> | CountInAmount<"count">;
+export type TokenInAmount = PercentInAmount | CountInAmount;
 
-export type PercentInAmount<T> = {
+export type PercentInAmount = {
   value: Decimal | OrcaU64;
   ownerPublicKey: PublicKey;
-  type: T;
+  type: "percent";
 };
 
-export type CountInAmount<T> = {
+export type CountInAmount = {
   value: Decimal | OrcaU64;
-  type: T;
+  type: "count";
 };
 
 /* DepositQuote types  */
@@ -25,19 +25,17 @@ export type DepositQuoteOutput = {
 };
 
 /* WithdrawQuote types */
-export type WithdrawQuoteAmount =
-  | PoolTokenInAmount<"poolToken">
-  | ConstraintTokenInAmount<"constraintToken">;
+export type WithdrawQuoteAmount = PoolTokenInAmount | ConstraintTokenInAmount;
 
-export type PoolTokenInAmount<T> = {
+export type PoolTokenInAmount = {
   poolTokenAmountIn: TokenInAmount;
-  type: T;
+  type: "poolToken";
 };
 
-export type ConstraintTokenInAmount<T> = {
+export type ConstraintTokenInAmount = {
   constraintTokenAmountIn: TokenInAmount;
   constraintTokenMint: PublicKey;
-  type: T;
+  type: "constraintToken";
 };
 
 export type WithdrawQuoteOutput = {

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -118,7 +118,7 @@ export type OrcaPool = {
    * @param maxTokenAIn The amount of token to deposit for token A (either raw count or percentage of owned)
    * @param maxTokenBIn The amount of token to deposit for token B (either raw count or percentgae of owned)
    * @param slippage An optional slippage in percentage you are willing to take in deposit (default: 0.1%)
-   * @return
+   * @return Input for deposit
    */
   getDepositQuote: (
     maxTokenAIn: TokenInAmount,
@@ -150,9 +150,9 @@ export type OrcaPool = {
   /**
    * Get minTokenAOut and mintTokenBOut amounts to be used for withdraw.
    *
-   * @param
+   * @param amountIn The amount of pool tokens to withdraw, amount expressed either directly in pool token or in one of the paired tokens
    * @param slippage An optional slippage in percentage you are willing to take in withdraw (default: 0.1%)
-   * @return
+   * @return Input for withdraw
    */
   getWithdrawQuote: (
     amountIn: WithdrawQuoteAmount,

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -32,7 +32,7 @@ export type OrcaPool = {
   getTokenB: () => OrcaPoolToken;
 
   /**
-   * Query the tokenMint public key of this pool.
+   * Query the mint public key for the pool token of this pool.
    * @returns Returns the tokenMint public key of this pool
    */
   getPoolTokenMint: () => PublicKey;

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -45,7 +45,7 @@ export type OrcaPool = {
   getQuote: (
     inputToken: OrcaToken,
     inputAmount: Decimal | OrcaU64,
-    slippage: Decimal
+    slippage?: Decimal
   ) => Promise<Quote>;
 
   /**

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -70,6 +70,19 @@ export type OrcaPool = {
   ) => Promise<TransactionPayload>;
 
   /**
+   * Get minPoolTokenAmountOut to be used for deposit.
+   *
+   * @param maxTokenAIn The amount of token to deposit for token A
+   * @param maxTokenBIn The amount of token to deposit for token B
+   * @param slippage The slippage in percentage you are willing to take in deposit
+   */
+  getDepositQuote: (
+    maxTokenAIn: Decimal | OrcaU64,
+    maxTokenBIn: Decimal | OrcaU64,
+    slippage?: Decimal
+  ) => Promise<OrcaU64>;
+
+  /**
    * Perform a deposit: send tokenA and tokenB, and receive a poolToken in return.
    * Fee for the transaction will be paid by the owner's wallet.
    *
@@ -89,6 +102,17 @@ export type OrcaPool = {
     maxTokenBIn: Decimal | OrcaU64,
     minPoolTokenAmountOut: Decimal | OrcaU64
   ) => Promise<TransactionPayload>;
+
+  /**
+   * Get minTokenAOut and mintTokenBOut amounts to be used for withdraw.
+   *
+   * @param poolTokenIn The amount of pool tokens to send in
+   * @param slippage The slippage in percentage you are willing to take in withdraw
+   */
+  getWithdrawQuote: (
+    poolTokenIn: Decimal | OrcaU64,
+    slippage?: Decimal
+  ) => Promise<{ minTokenAOut: OrcaU64; minTokenBOut: OrcaU64 }>;
 
   /**
    * Perform a withdraw: send poolToken, and receive tokenA and tokenB in return.

--- a/src/public/utils/web3/get-token-count.ts
+++ b/src/public/utils/web3/get-token-count.ts
@@ -9,6 +9,25 @@ export type PoolTokenCount = {
   outputTokenCount: u64;
 };
 
+export async function getSingleTokenCount(
+  connection: Connection,
+  poolParams: OrcaPoolParams,
+  token: OrcaPoolToken
+): Promise<u64> {
+  if (poolParams.tokens[token.mint.toString()] == undefined) {
+    throw new Error("Token not part of pool");
+  }
+
+  const accountInfo = await connection.getAccountInfo(token.addr);
+  const tokenAccount = accountInfo && deserializeAccount(accountInfo.data);
+
+  if (!tokenAccount) {
+    throw new Error("Unable to fetch account for the token");
+  }
+
+  return new u64(tokenAccount.amount);
+}
+
 export async function getTokenCount(
   connection: Connection,
   poolParams: OrcaPoolParams,

--- a/src/public/utils/web3/get-token-count.ts
+++ b/src/public/utils/web3/get-token-count.ts
@@ -9,25 +9,6 @@ export type PoolTokenCount = {
   outputTokenCount: u64;
 };
 
-export async function getSingleTokenCount(
-  connection: Connection,
-  poolParams: OrcaPoolParams,
-  token: OrcaPoolToken
-): Promise<u64> {
-  if (poolParams.tokens[token.mint.toString()] == undefined) {
-    throw new Error("Token not part of pool");
-  }
-
-  const accountInfo = await connection.getAccountInfo(token.addr);
-  const tokenAccount = accountInfo && deserializeAccount(accountInfo.data);
-
-  if (!tokenAccount) {
-    throw new Error("Unable to fetch account for the token");
-  }
-
-  return new u64(tokenAccount.amount);
-}
-
 export async function getTokenCount(
   connection: Connection,
   poolParams: OrcaPoolParams,

--- a/src/public/utils/web3/get-token-count.ts
+++ b/src/public/utils/web3/get-token-count.ts
@@ -1,9 +1,6 @@
-import { TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
-import { Connection, PublicKey } from "@solana/web3.js";
-import Decimal from "decimal.js";
-import { DecimalUtil, OrcaU64, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, U64Utils } from "..";
-import { OrcaPoolToken, TokenInAmount } from "../..";
-import { solToken } from "../../../constants/tokens";
+import { u64 } from "@solana/spl-token";
+import { Connection } from "@solana/web3.js";
+import { OrcaPoolToken } from "../..";
 import { OrcaPoolParams } from "../../../model/orca/pool/pool-types";
 import { deserializeAccount } from "./deserialize-account";
 
@@ -46,74 +43,4 @@ export async function getTokenCount(
     inputTokenCount: new u64(inputTokenAccount.amount),
     outputTokenCount: new u64(outputTokenAccount.amount),
   };
-}
-
-async function getUserTokenCount(
-  connection: Connection,
-  ownerPublicKey: PublicKey,
-  tokenMint: PublicKey,
-  tokenScale: number
-): Promise<Decimal> {
-  // Special case: SOL doesn't have ATA
-  if (tokenMint === solToken.mint) {
-    const balance = await connection.getBalance(ownerPublicKey);
-    return DecimalUtil.fromU64(new u64(balance), solToken.scale);
-  }
-
-  const ownerATAPublicKey = (
-    await PublicKey.findProgramAddress(
-      [ownerPublicKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), tokenMint.toBuffer()],
-      SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID
-    )
-  )[0];
-  const accountInfo = await connection.getAccountInfo(ownerATAPublicKey);
-  const tokenAccount = accountInfo && deserializeAccount(accountInfo.data);
-
-  if (!tokenAccount) {
-    throw new Error(`Unable to fetch user account for token with mint ${tokenMint}`);
-  }
-
-  return DecimalUtil.fromU64(tokenAccount.amount, tokenScale);
-}
-
-export async function getTokenInAmount(
-  connection: Connection,
-  token: OrcaPoolToken,
-  tokenInAmount: TokenInAmount
-): Promise<u64> {
-  if (tokenInAmount.type === "count") {
-    return U64Utils.toTokenU64(tokenInAmount.value, token, `tokenInAmount-${token.name}`);
-  }
-
-  const totalUserTokenCount = await getUserTokenCount(
-    connection,
-    tokenInAmount.ownerPublicKey,
-    token.mint,
-    token.scale
-  );
-  const percentage =
-    tokenInAmount.value instanceof OrcaU64 ? tokenInAmount.value.toDecimal() : tokenInAmount.value;
-  const amount = totalUserTokenCount.mul(percentage);
-  return U64Utils.toTokenU64(amount, token, `tokenInAmount-${token.name}`);
-}
-
-export async function getPoolTokenInAmount(
-  connection: Connection,
-  pool: OrcaPoolParams,
-  tokenInAmount: TokenInAmount
-): Promise<u64> {
-  if (tokenInAmount.type === "count") {
-    return U64Utils.toPoolU64(tokenInAmount.value, pool, "tokenInAmount");
-  }
-
-  const totalUserTokenCount = await getUserTokenCount(
-    connection,
-    tokenInAmount.ownerPublicKey,
-    pool.poolTokenMint,
-    pool.poolTokenDecimals
-  );
-  const percentage =
-    tokenInAmount.value instanceof OrcaU64 ? tokenInAmount.value.toDecimal() : tokenInAmount.value;
-  const amount = totalUserTokenCount.mul(percentage);
-  return U64Utils.toPoolU64(amount, pool, "tokenInAmount");
 }

--- a/src/public/utils/web3/get-token-count.ts
+++ b/src/public/utils/web3/get-token-count.ts
@@ -3,6 +3,7 @@ import { Connection, PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
 import { DecimalUtil, OrcaU64, SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID, U64Utils } from "..";
 import { OrcaPoolToken, TokenInAmount } from "../..";
+import { solToken } from "../../../constants/tokens";
 import { OrcaPoolParams } from "../../../model/orca/pool/pool-types";
 import { deserializeAccount } from "./deserialize-account";
 
@@ -52,6 +53,12 @@ async function getUserTokenCount(
   ownerPublicKey: PublicKey,
   tokenMint: PublicKey
 ): Promise<Decimal> {
+  // Special case: SOL doesn't have ATA
+  if (tokenMint === solToken.mint) {
+    const balance = await connection.getBalance(ownerPublicKey);
+    return DecimalUtil.fromU64(new u64(balance), solToken.scale);
+  }
+
   const ownerATAPublicKey = (
     await PublicKey.findProgramAddress(
       [ownerPublicKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), tokenMint.toBuffer()],


### PR DESCRIPTION
### Context

* Currently, the client has to do math to figure out parameters for pool deposit and withdraw. We should provide functions that calculates these values

### Changes

* new pool api `getDepositQuote(maxTokenAIn, maxTokenBIn, slippage?)`
* new pool api `getWithdrawQuote(poolTokenIn, slippage?)`

### Usage Example

```typescript
const orca = getOrca(connection);
const pool = orca.getPool(OrcaPoolConfig.ORCA_SOL);

const orcaAmount = new Decimal(10);
const quote = await pool.getQuote(pool.getTokenA(), orcaAmount);
const solAmount = quote.getMinOutputAmount();
const poolTokenAmount = await pool.getDepositQuote(orcaAmount, solAmount); // <-- NEW

console.log(`Deposit at most ${orcaAmount} ORCA and ${solAmount} SOL, for at least ${
  poolTokenAmount
} pool tokens`);

const depositPayload = await pool.deposit(owner, orcaAmount, solAmount, poolTokenAmount);
const depositTxId = await depositPayload.execute();

console.log("Confirmation:", depositTxId);
```