### PR TITLE
Batch get token count

### DIFF
--- a/src/public/utils/web3/get-token-count.ts
+++ b/src/public/utils/web3/get-token-count.ts
@@ -23,10 +23,9 @@ export async function getTokenCount(
     throw new Error("Output token not part of pool");
   }
 
-  // TODO: Batch request?
-  const accountInfos = await Promise.all([
-    connection.getAccountInfo(inputPoolToken.addr),
-    connection.getAccountInfo(outputPoolToken.addr),
+  const accountInfos = await connection.getMultipleAccountsInfo([
+    inputPoolToken.addr,
+    outputPoolToken.addr,
   ]);
 
   const tokens = accountInfos.map((info) =>


### PR DESCRIPTION
Another thing that generate unnecessary requests is this call in `getQuote`:

https://github.com/orca-so/typescript-sdk/blob/8168fd229d2ef1c817adaec017608646a7f97141/src/model/orca/pool/orca-pool.ts#L108-L110