### PR TITLE
Add devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ main()
   });
 ```
 
+# Devnet Testing
+
+The example code above can be run on devnet by changing two lines of code like so:
+
+```typescript
+const connection = new Connection("https://api.devnet.solana.com", "singleGossip");
+const orca = getOrca(connection, Network.DEVNET);
+```
+
+One caveat to note is that there are only a few devnet pools avaialble, so if you try to access pools that are only
+available on mainnet, the code will throw an error. The example code uses ORCA_SOL, which exists on the devnet.
+
 # Technical Notes
 
 **Decimals & OrcaU64**

--- a/src/constants/devnet/farms.ts
+++ b/src/constants/devnet/farms.ts
@@ -1,0 +1,113 @@
+import { PublicKey } from "@solana/web3.js";
+import { OrcaFarmParams } from "../../model/orca/farm/farm-types";
+
+/**
+ * The following content is auto-generated.
+ */
+
+export const solUsdcAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("CzFnr34cRC1o8yrs5jTHBqDQ1FDckLapkPis6zTfqCF5"),
+  farmTokenMint: new PublicKey("AtJF9fbQ1pbz76NYo2jtKjHuzzyaFToHLCizYk6UoHHL"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7"),
+  baseTokenDecimals: 6,
+});
+
+export const solUsdtAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("ER1UZsRhzucvXY8xMmXGfbbxb442iTHk2u1rSKRMPakC"),
+  farmTokenMint: new PublicKey("E95ABqtqnJRMG6gqEKZ16dVMfSNDUdCbEYqGUVg3tFRX"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2"),
+  baseTokenDecimals: 6,
+});
+
+export const usdcUsdtAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("D7wWV4nxqEeCAk2UA2nEGWgKw2BgoZYFZFUfwWGBhDF8"),
+  farmTokenMint: new PublicKey("3dDqVehvEpc5HMcbJUAzwMwF54xqa4nNvYN9qis7HAPe"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv"),
+  baseTokenDecimals: 6,
+});
+
+export const ethSolAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("3q4wtMRT2yKHzQGy6gxwD34i9rsafviKd78rpdDLrBfk"),
+  farmTokenMint: new PublicKey("5NH9rNaoLKbPPP5zwCJTaMPkFACtfJA8wEmqWrXzgCMa"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL"),
+  baseTokenDecimals: 6,
+});
+
+export const ethUsdcAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("3aRTv8TGtZkX4dsM4N9aUHKotcwRr6phWPHXPLN8DEYX"),
+  farmTokenMint: new PublicKey("EeqPcczEZH2cjYBnQyGXBQx1DGs7KG1pobwdPKcwALhD"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA"),
+  baseTokenDecimals: 6,
+});
+
+export const orcaSolAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("6YrLcQs5yFvXkRY5VkMGEfVgo5rwozJf7jXedpZxbKmi"),
+  farmTokenMint: new PublicKey("3z8o3b4gMBpnRsrDv7ruZPcVtgoULMFyEoEEGwTsw2TR"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi"),
+  baseTokenDecimals: 6,
+});
+
+export const orcaUsdcAqFarm: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("44GPPv5XedLXCNCc3Mbay1T18vc6x2bWihmmg7UJanvH"),
+  farmTokenMint: new PublicKey("52Tv8d6Z7Lb27dqCufZPUqadZBTv3EAKGzoV6hy185As"),
+  rewardTokenMint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri"),
+  baseTokenDecimals: 6,
+});
+
+export const solUsdcDoubleDip: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("L3XdTwLLtZRrXqSk5mqcBKaorqgmM2AMDGmzfBuhLMd"),
+  farmTokenMint: new PublicKey("7AYG2y3je8TqcLsugNkV6aPw14QyqdVFmK5EegeJmRFi"),
+  rewardTokenMint: new PublicKey("Ff5JqsAYUD4vAfQUtfRprT4nXu9e28tTBZTDFMnJNdvd"),
+  rewardTokenDecimals: 9,
+  baseTokenMint: new PublicKey("AtJF9fbQ1pbz76NYo2jtKjHuzzyaFToHLCizYk6UoHHL"),
+  baseTokenDecimals: 6,
+});
+
+export const ethSolDoubleDip: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("5jGfcgoRNpZPwfiRTp5zxNpEKP3PTeM3F9EKS9EsvX67"),
+  farmTokenMint: new PublicKey("5Uv5T1BksJGKGFGVpfxGeGniFFgGLjavNpPWGkfUFNkr"),
+  rewardTokenMint: new PublicKey("6PE3Mwjzx9h8kCoBp5YPed9TFoG7du8L98yucBP5ps3x"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("5NH9rNaoLKbPPP5zwCJTaMPkFACtfJA8wEmqWrXzgCMa"),
+  baseTokenDecimals: 6,
+});
+
+export const ethUsdcDoubleDip: OrcaFarmParams = Object.freeze({
+  address: new PublicKey("B4CTmaFpNRtXL3ZLiLrgbMZknQHFdoGu4V9tbzsjFbRT"),
+  farmTokenMint: new PublicKey("5jdeMPvNrscuw8abZFf99X9kcxDhANcpuBHDNpnx7YPT"),
+  rewardTokenMint: new PublicKey("EmXq3Ni9gfudTiyNKzzYvpnQqnJEMRw2ttnVXoJXjLo1"),
+  rewardTokenDecimals: 6,
+  baseTokenMint: new PublicKey("EeqPcczEZH2cjYBnQyGXBQx1DGs7KG1pobwdPKcwALhD"),
+  baseTokenDecimals: 6,
+});
+
+/**
+ * Mapping for OrcaFarm parameters
+ * Key: baseTokenMint : OrcaFarmParams
+ */
+export const orcaDevnetFarmConfigs: Record<string, OrcaFarmParams> = {
+  "4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7": solUsdcAqFarm,
+  "2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2": solUsdtAqFarm,
+  EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv: usdcUsdtAqFarm,
+  "8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL": ethSolAqFarm,
+  "9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA": ethUsdcAqFarm,
+  CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi: orcaSolAqFarm,
+  "2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri": orcaUsdcAqFarm,
+  AtJF9fbQ1pbz76NYo2jtKjHuzzyaFToHLCizYk6UoHHL: solUsdcDoubleDip,
+  "5NH9rNaoLKbPPP5zwCJTaMPkFACtfJA8wEmqWrXzgCMa": ethSolDoubleDip,
+  EeqPcczEZH2cjYBnQyGXBQx1DGs7KG1pobwdPKcwALhD: ethUsdcDoubleDip,
+};

--- a/src/constants/devnet/index.ts
+++ b/src/constants/devnet/index.ts
@@ -1,0 +1,2 @@
+export { orcaDevnetPoolConfigs } from "./pools";
+export { orcaDevnetFarmConfigs } from "./farms";

--- a/src/constants/devnet/pools.ts
+++ b/src/constants/devnet/pools.ts
@@ -1,0 +1,198 @@
+import { PublicKey } from "@solana/web3.js";
+import { CurveType, OrcaPoolParams } from "../../model/orca/pool/pool-types";
+import { Percentage } from "../../public/utils/models/percentage";
+import * as Tokens from "./tokens";
+
+/**
+ * The following content is auto-generated.
+ */
+
+export const solUsdcPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("8DT1oKJPHcdJzdSf3cb2WT7L8eRjLUJeDFSe7M2QDtQE"),
+  nonce: 255,
+  authority: new PublicKey("BVSZP6RsqAtjvuJrXYsYN5U4XY7pLwW4PawfgVPkLbjN"),
+  poolTokenMint: new PublicKey("4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("HPzaLqtZGhTbs7WcdGMfLswKze28W75nrYytNSw7qdvi"),
+  tokenIds: [Tokens.solToken.mint.toString(), Tokens.usdcToken.mint.toString()],
+  tokens: {
+    [Tokens.solToken.mint.toString()]: {
+      ...Tokens.solToken,
+      addr: new PublicKey("4ShvTPQ3jYZzwUpxoQFSCDZxLtxQYNPUfeL3sR9mzLjJ"),
+    },
+    [Tokens.usdcToken.mint.toString()]: {
+      ...Tokens.usdcToken,
+      addr: new PublicKey("9eKgmUSfTkQLRBvowV9zjY3BbhAQVaGSw1jfon5UwUJM"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+export const solUsdtPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("65AsoozQfBedPU3rGCB7CfBbSFhiFGaVQaeoF9mLFM3g"),
+  nonce: 255,
+  authority: new PublicKey("59Pu3srqBDSgWrSJKuh7xcb5omJeVkMw41eFswDWKPat"),
+  poolTokenMint: new PublicKey("2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("HmRP17zbgJUPPeueLjT2b1HVKt16CTixSJX6UpGkkZnp"),
+  tokenIds: [Tokens.solToken.mint.toString(), Tokens.usdtToken.mint.toString()],
+  tokens: {
+    [Tokens.solToken.mint.toString()]: {
+      ...Tokens.solToken,
+      addr: new PublicKey("BhJsBxGoe39HWtwFTCxRZGhPNVZ5x9Rr2gFzNsaA6ES8"),
+    },
+    [Tokens.usdtToken.mint.toString()]: {
+      ...Tokens.usdtToken,
+      addr: new PublicKey("Ea2gPV96MQthA5CCS4NincVidxsN8JifWhBoMJVHx8mZ"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+export const usdcUsdtPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("4UJqLypzZzDvoAWCLt6qWEoddMYoSLjrJEB13AfRmV68"),
+  nonce: 255,
+  authority: new PublicKey("52Sp73fASLtZhBPyZu7rQoejG9sNzpNLaTTF4mJJGZge"),
+  poolTokenMint: new PublicKey("EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("6RjV63TfeJDL7K6j8cUnaT6mWXKxqsrDFrumvqGRwss6"),
+  tokenIds: [Tokens.usdcToken.mint.toString(), Tokens.usdtToken.mint.toString()],
+  tokens: {
+    [Tokens.usdcToken.mint.toString()]: {
+      ...Tokens.usdcToken,
+      addr: new PublicKey("Fp9PioKwFc6vmQZ5yB2pPSSx5VqkLhgX21dQYug79yUQ"),
+    },
+    [Tokens.usdtToken.mint.toString()]: {
+      ...Tokens.usdtToken,
+      addr: new PublicKey("GazSkg8GU4cti8Dm1cYD74CQf9UXQdUzBsP27YhC4SCt"),
+    },
+  },
+  curveType: CurveType.Stable,
+  amp: 100,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(9, 10000),
+    ownerFee: Percentage.fromFraction(1, 10000),
+  },
+});
+
+export const ethSolPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("F9MgdfFEshXCTGbppcVr2DzpVxqkiVowGqd95S4vpC6D"),
+  nonce: 251,
+  authority: new PublicKey("FD1UJqbXtiYnMcKxcDG4MYY1vasupm2sYXAkStQhSpTb"),
+  poolTokenMint: new PublicKey("8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("8zyAMewVQuHBxJeqn5oRvanDaaEZ9uYxjHxJ9DYCRsgn"),
+  tokenIds: [Tokens.ethToken.mint.toString(), Tokens.solToken.mint.toString()],
+  tokens: {
+    [Tokens.ethToken.mint.toString()]: {
+      ...Tokens.ethToken,
+      addr: new PublicKey("FJetz1Du8p2NWmfa9DNvHR8zC42tUCHsY3YfnkZNyZfT"),
+    },
+    [Tokens.solToken.mint.toString()]: {
+      ...Tokens.solToken,
+      addr: new PublicKey("37o62xYE1a43Ap8neq6SdrutxQKFsFHicRamkcjHigKs"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+export const ethUsdcPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("CVH3UX1fePV3fn4dE2irNgni2uRkPdEWyZeCZS5b63F3"),
+  nonce: 255,
+  authority: new PublicKey("3uf9wngmqKdBdrWPM9iKsXQE829sg7gH9oJghcrpePhh"),
+  poolTokenMint: new PublicKey("9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("9AekLW8Dq5T1XnLLC2rQscS4Y5YN2QwrYA7eaGdq7Xje"),
+  tokenIds: [Tokens.ethToken.mint.toString(), Tokens.usdcToken.mint.toString()],
+  tokens: {
+    [Tokens.ethToken.mint.toString()]: {
+      ...Tokens.ethToken,
+      addr: new PublicKey("C7eYGeiroWzuPgqruxRmgj3xw978gRZpPTov2kqxBRpx"),
+    },
+    [Tokens.usdcToken.mint.toString()]: {
+      ...Tokens.usdcToken,
+      addr: new PublicKey("DRdNFrRqWpqQHhJDymyZvgHBH2vTkUo5jzzTwWy7RT4h"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+export const orcaSolPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("B4v9urCKnrdCMWt7rEPyA5xyuEeYQv4aDpCfGFVaCvox"),
+  nonce: 252,
+  authority: new PublicKey("38Q2148y3BKU6pDUfv1zpeEeKNuDHBH34WdEwo5EiTfe"),
+  poolTokenMint: new PublicKey("CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("EEWAuP2d1KbwX14dgHwxXspPMYfxXvgf4CNRYvMakPHg"),
+  tokenIds: [Tokens.orcaToken.mint.toString(), Tokens.solToken.mint.toString()],
+  tokens: {
+    [Tokens.orcaToken.mint.toString()]: {
+      ...Tokens.orcaToken,
+      addr: new PublicKey("HsGXFtv1uBTtWuPCEJWpxZS4QkcHwAhdPaMVSvS4fhtv"),
+    },
+    [Tokens.solToken.mint.toString()]: {
+      ...Tokens.solToken,
+      addr: new PublicKey("3coXPvurzHQ6sYLrYi8zGWG7SLVv9mHnbqmchjKgPEmz"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+export const orcaUsdcPool: OrcaPoolParams = Object.freeze({
+  address: new PublicKey("GaCKuVZyo6HxUf6bkcWzDETGHqqViF6H77ax7Uxq3LXU"),
+  nonce: 255,
+  authority: new PublicKey("3KVqBR9cB4tNHwpNPZtedegXbQ8FbWgjzk5oob7QRnHt"),
+  poolTokenMint: new PublicKey("2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri"),
+  poolTokenDecimals: 6,
+  feeAccount: new PublicKey("9yVp1tUHNxorNZgXAs6thPeizCryHTebjKG4P8uUdXuv"),
+  tokenIds: [Tokens.orcaToken.mint.toString(), Tokens.usdcToken.mint.toString()],
+  tokens: {
+    [Tokens.orcaToken.mint.toString()]: {
+      ...Tokens.orcaToken,
+      addr: new PublicKey("7KAqhu58omLjKjg1XNSw28JULED82mnA1vvAMVoAdA6T"),
+    },
+    [Tokens.usdcToken.mint.toString()]: {
+      ...Tokens.usdcToken,
+      addr: new PublicKey("8E2CH9fPNXbc5pqu1dWWkNsNZWvLcBEXdBnzzXuhvJNL"),
+    },
+  },
+  curveType: CurveType.ConstantProduct,
+  feeStructure: {
+    traderFee: Percentage.fromFraction(25, 10000),
+    ownerFee: Percentage.fromFraction(5, 10000),
+  },
+});
+
+/**
+ * Mapping for OrcaPool parameters
+ * Key: poolTokenMint : OrcaPoolParams
+ */
+export const orcaDevnetPoolConfigs: Record<string, OrcaPoolParams> = {
+  "4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7": solUsdcPool,
+  "2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2": solUsdtPool,
+  EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv: usdcUsdtPool,
+  "8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL": ethSolPool,
+  "9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA": ethUsdcPool,
+  CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi: orcaSolPool,
+  "2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri": orcaUsdcPool,
+};

--- a/src/constants/devnet/tokens.ts
+++ b/src/constants/devnet/tokens.ts
@@ -1,0 +1,41 @@
+import { PublicKey } from "@solana/web3.js";
+import { OrcaToken } from "../..";
+
+/**
+ * The following content is auto-generated.
+ */
+
+export const ethToken: OrcaToken = Object.freeze({
+  tag: "ETH",
+  name: "Ethereum",
+  mint: new PublicKey("Ff5JqsAYUD4vAfQUtfRprT4nXu9e28tTBZTDFMnJNdvd"),
+  scale: 9,
+});
+
+export const orcaToken: OrcaToken = Object.freeze({
+  tag: "ORCA",
+  name: "Orca",
+  mint: new PublicKey("orcarKHSqC5CDDsGbho8GKvwExejWHxTqGzXgcewB9L"),
+  scale: 6,
+});
+
+export const solToken: OrcaToken = Object.freeze({
+  tag: "SOL",
+  name: "Solana",
+  mint: new PublicKey("So11111111111111111111111111111111111111112"),
+  scale: 9,
+});
+
+export const usdcToken: OrcaToken = Object.freeze({
+  tag: "USDC",
+  name: "USD Coin",
+  mint: new PublicKey("EmXq3Ni9gfudTiyNKzzYvpnQqnJEMRw2ttnVXoJXjLo1"),
+  scale: 6,
+});
+
+export const usdtToken: OrcaToken = Object.freeze({
+  tag: "USDT",
+  name: "Tether USD",
+  mint: new PublicKey("6PE3Mwjzx9h8kCoBp5YPed9TFoG7du8L98yucBP5ps3x"),
+  scale: 6,
+});

--- a/src/model/orca-factory.ts
+++ b/src/model/orca-factory.ts
@@ -1,15 +1,27 @@
 import { Connection } from "@solana/web3.js";
-import { OrcaPoolConfig, OrcaPool, OrcaFarmConfig, OrcaFarm } from "..";
+import { OrcaPoolConfig, OrcaPool, OrcaFarmConfig, OrcaFarm, Network } from "..";
 import { orcaPoolConfigs, orcaFarmConfigs } from "../constants";
+import { orcaDevnetFarmConfigs, orcaDevnetPoolConfigs } from "../constants/devnet";
+import { getDevnetFarm, getDevnetPool } from "../public/devnet";
 import { OrcaFarmImpl } from "./orca/farm/orca-farm";
 import { OrcaPoolImpl } from "./orca/pool/orca-pool";
 
 export class OrcaFactory {
-  getPool(connection: Connection, config: OrcaPoolConfig): OrcaPool {
-    return new OrcaPoolImpl(connection, orcaPoolConfigs[config]);
+  getPool(connection: Connection, network: Network, config: OrcaPoolConfig): OrcaPool {
+    if (network === Network.DEVNET) {
+      const devnetConfig = getDevnetPool(config);
+      return new OrcaPoolImpl(connection, network, orcaDevnetPoolConfigs[devnetConfig]);
+    }
+
+    return new OrcaPoolImpl(connection, network, orcaPoolConfigs[config]);
   }
 
-  getFarm(connection: Connection, config: OrcaFarmConfig): OrcaFarm {
+  getFarm(connection: Connection, network: Network, config: OrcaFarmConfig): OrcaFarm {
+    if (network === Network.DEVNET) {
+      const devnetConfig = getDevnetFarm(config);
+      return new OrcaFarmImpl(connection, orcaDevnetFarmConfigs[devnetConfig]);
+    }
+
     return new OrcaFarmImpl(connection, orcaFarmConfigs[config]);
   }
 }

--- a/src/model/orca/orca-impl.ts
+++ b/src/model/orca/orca-impl.ts
@@ -1,21 +1,23 @@
 import { Connection } from "@solana/web3.js";
-import { Orca, OrcaFarm, OrcaPool, OrcaPoolConfig, OrcaFarmConfig } from "../../public";
+import { Orca, OrcaFarm, OrcaPool, OrcaPoolConfig, OrcaFarmConfig, Network } from "../../public";
 import { OrcaFactory } from "../orca-factory";
 
 export class OrcaImpl implements Orca {
   private connection: Connection;
+  private network: Network;
   private factory: OrcaFactory;
 
-  constructor(connection: Connection) {
+  constructor(connection: Connection, network: Network) {
     this.connection = connection;
+    this.network = network;
     this.factory = new OrcaFactory();
   }
 
   getPool(pool: OrcaPoolConfig): OrcaPool {
-    return this.factory.getPool(this.connection, pool);
+    return this.factory.getPool(this.connection, this.network, pool);
   }
 
   getFarm(farm: OrcaFarmConfig): OrcaFarm {
-    return this.factory.getFarm(this.connection, farm);
+    return this.factory.getFarm(this.connection, this.network, farm);
   }
 }

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -23,6 +23,9 @@ import {
   DepositQuote,
   WithdrawQuote,
   DecimalUtil,
+  Network,
+  ORCA_TOKEN_SWAP_ID_DEVNET,
+  ORCA_TOKEN_SWAP_ID,
 } from "../../../public";
 import {
   createApprovalInstruction,
@@ -37,10 +40,14 @@ import { OrcaPoolParams } from "./pool-types";
 export class OrcaPoolImpl implements OrcaPool {
   private connection: Connection;
   private poolParams: OrcaPoolParams;
+  private orcaTokenSwapId: PublicKey;
 
-  constructor(connection: Connection, config: OrcaPoolParams) {
+  constructor(connection: Connection, network: Network, config: OrcaPoolParams) {
     this.connection = connection;
     this.poolParams = config;
+
+    this.orcaTokenSwapId =
+      network === Network.MAINNET ? ORCA_TOKEN_SWAP_ID : ORCA_TOKEN_SWAP_ID_DEVNET;
   }
 
   public getTokenA(): OrcaPoolToken {
@@ -181,7 +188,8 @@ export class OrcaPoolImpl implements OrcaPool {
       outputPoolTokenUserAddress,
       amountInU64,
       minimumAmountOutU64,
-      userTransferAuthority.publicKey
+      userTransferAuthority.publicKey,
+      this.orcaTokenSwapId
     );
 
     return await new TransactionBuilder(this.connection, ownerAddress, _owner)
@@ -316,6 +324,7 @@ export class OrcaPoolImpl implements OrcaPool {
       maxTokenBIn_U64,
       tokenA.addr,
       tokenB.addr,
+      this.orcaTokenSwapId,
       _owner
     );
 
@@ -464,6 +473,7 @@ export class OrcaPoolImpl implements OrcaPool {
       minTokenBOut_U64,
       tokenA.addr,
       tokenB.addr,
+      this.orcaTokenSwapId,
       _owner
     );
 

--- a/src/public/devnet/farms/config.ts
+++ b/src/public/devnet/farms/config.ts
@@ -1,0 +1,19 @@
+/**
+ * The following content is auto-generated.
+ */
+
+/**
+ * A list of supported Orca farms in this SDK.
+ */
+export enum OrcaFarmConfig {
+  SOL_USDC_AQ = "4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7",
+  SOL_USDT_AQ = "2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2",
+  USDC_USDT_AQ = "EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv",
+  ETH_SOL_AQ = "8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL",
+  ETH_USDC_AQ = "9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA",
+  ORCA_SOL_AQ = "CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi",
+  ORCA_USDC_AQ = "2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri",
+  SOL_USDC_DD = "AtJF9fbQ1pbz76NYo2jtKjHuzzyaFToHLCizYk6UoHHL",
+  ETH_SOL_DD = "5NH9rNaoLKbPPP5zwCJTaMPkFACtfJA8wEmqWrXzgCMa",
+  ETH_USDC_DD = "EeqPcczEZH2cjYBnQyGXBQx1DGs7KG1pobwdPKcwALhD",
+}

--- a/src/public/devnet/index.ts
+++ b/src/public/devnet/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/src/public/devnet/pools/config.ts
+++ b/src/public/devnet/pools/config.ts
@@ -1,0 +1,16 @@
+/**
+ * The following content is auto-generated.
+ */
+
+/**
+ * A list of supported Orca pools in this SDK.
+ */
+export enum OrcaPoolConfig {
+  SOL_USDC = "4GpUivZ2jvZqQ3vJRsoq5PwnYv6gdV9fJ9BzHT2JcRr7",
+  SOL_USDT = "2E4Mp6y2gFRteXiANnwzAJEhHwD3NX1wru3XvxJpGBq2",
+  USDC_USDT = "EBor1PR5XNGHjRVB6JDJuKVCQbvdr1CVZTaX1hTAdvQv",
+  ETH_SOL = "8sFnpd7mM1AWxP1LXX2FWbbkaVtAopBPmPNZ9y6172WL",
+  ETH_USDC = "9pRnvg7ihSJDLi6DGf3PLwr6xRRRrBPXsHYEgGL5hzgA",
+  ORCA_SOL = "CmDdQhusZWyi9fue27VSktYgkHefm3JXNdzc9kCpyvYi",
+  ORCA_USDC = "2ZEEntzoUN7XuMs88ukLGv5HRR1byL7wFWChryF5ZHri",
+}

--- a/src/public/devnet/utils.ts
+++ b/src/public/devnet/utils.ts
@@ -1,0 +1,41 @@
+import { OrcaPoolConfig, OrcaFarmConfig } from "..";
+import { OrcaFarmConfig as OrcaDevnetFarmConfig } from "./farms/config";
+import { OrcaPoolConfig as OrcaDevnetPoolConfig } from "./pools/config";
+
+export function getDevnetPool(config: OrcaPoolConfig): OrcaDevnetPoolConfig {
+  const entry = Object.entries(OrcaPoolConfig).find((arr) => arr[1] === config);
+  if (!entry) {
+    throw new Error("Invalid OrcaPoolConfig");
+  }
+
+  const key = entry[0];
+  if (!isOrcaDevnetPoolConfig(key)) {
+    throw new Error(`${key} does not exist in devnet`);
+  }
+
+  return OrcaDevnetPoolConfig[key];
+}
+
+export function getDevnetFarm(config: OrcaFarmConfig): OrcaDevnetFarmConfig {
+  const entry = Object.entries(OrcaFarmConfig).find((arr) => arr[1] === config);
+  if (!entry) {
+    throw new Error("Invalid OrcaFarmConfig");
+  }
+
+  const key = entry[0];
+  if (!isOrcaDevnetFarmConfig(key)) {
+    throw new Error(`${key} does not exist in devnet`);
+  }
+
+  return OrcaDevnetFarmConfig[key];
+}
+
+/*** Type guards ***/
+
+function isOrcaDevnetPoolConfig(key: string): key is keyof typeof OrcaDevnetPoolConfig {
+  return OrcaDevnetPoolConfig[key as keyof typeof OrcaDevnetPoolConfig] !== undefined;
+}
+
+function isOrcaDevnetFarmConfig(key: string): key is keyof typeof OrcaDevnetFarmConfig {
+  return OrcaDevnetFarmConfig[key as keyof typeof OrcaDevnetFarmConfig] !== undefined;
+}

--- a/src/public/main/orca.ts
+++ b/src/public/main/orca.ts
@@ -1,4 +1,5 @@
 import { Connection } from "@solana/web3.js";
+import { Network } from "..";
 import { OrcaImpl } from "../../model/orca/orca-impl";
 import { Orca } from "./types";
 
@@ -7,6 +8,6 @@ import { Orca } from "./types";
  * @param connection Solana connection class
  * @returns An instance of Orca SDK
  */
-export function getOrca(connection: Connection): Orca {
-  return new OrcaImpl(connection);
+export function getOrca(connection: Connection, network = Network.MAINNET): Orca {
+  return new OrcaImpl(connection, network);
 }

--- a/src/public/utils/constants.ts
+++ b/src/public/utils/constants.ts
@@ -4,6 +4,10 @@ export const ORCA_TOKEN_SWAP_ID: PublicKey = new PublicKey(
   "9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP"
 );
 
+export const ORCA_TOKEN_SWAP_ID_DEVNET: PublicKey = new PublicKey(
+  "3xQ8SWv2GaFXXpHZNqkXsdxq5DZciHBz6ZFoPPfbFd7U"
+);
+
 export const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID: PublicKey = new PublicKey(
   "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 );

--- a/src/public/utils/index.ts
+++ b/src/public/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./numbers";
 export * from "./pool-utils";
 export * from "./time-utils";
 export * from "./web3";
+export * from "./types";

--- a/src/public/utils/types.ts
+++ b/src/public/utils/types.ts
@@ -1,0 +1,4 @@
+export enum Network {
+  MAINNET = "mainnet-beta",
+  DEVNET = "devnet",
+}

--- a/src/public/utils/web3/ata-utils.ts
+++ b/src/public/utils/web3/ata-utils.ts
@@ -29,7 +29,7 @@ export async function resolveOrCreateAssociatedTokenAddress(
   tokenMint: PublicKey,
   wrappedSolAmountIn = new u64(0)
 ): Promise<ResolvedTokenAddressInstruction> {
-  if (tokenMint !== solToken.mint) {
+  if (!tokenMint.equals(solToken.mint)) {
     const derivedAddress = await deriveAssociatedTokenAddress(owner.publicKey, tokenMint);
 
     // Check if current wallet has an ATA for this spl-token mint. If not, create one.

--- a/src/public/utils/web3/instructions/pool-instructions.ts
+++ b/src/public/utils/web3/instructions/pool-instructions.ts
@@ -3,7 +3,6 @@ import { TokenSwap } from "@solana/spl-token-swap";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { OrcaPoolParams } from "../../../../model/orca/pool/pool-types";
 import { OrcaPoolToken } from "../../../pools";
-import { ORCA_TOKEN_SWAP_ID } from "../../constants";
 import { Instruction } from "../../models";
 import { Owner } from "../key-utils";
 
@@ -48,14 +47,15 @@ export const createSwapInstruction = async (
   outputTokenUserAddress: PublicKey,
   amountIn: u64,
   minimumAmountOut: u64,
-  userTransferAuthority: PublicKey
+  userTransferAuthority: PublicKey,
+  orcaTokenSwapId: PublicKey
 ): Promise<Instruction> => {
   const amountInU64 = amountIn;
   const minimumAmountOutU64 = minimumAmountOut;
 
   const [authorityForPoolAddress] = await PublicKey.findProgramAddress(
     [poolParams.address.toBuffer()],
-    ORCA_TOKEN_SWAP_ID
+    orcaTokenSwapId
   );
 
   const swapInstruction = TokenSwap.swapInstruction(
@@ -69,7 +69,7 @@ export const createSwapInstruction = async (
     poolParams.poolTokenMint,
     poolParams.feeAccount,
     null,
-    ORCA_TOKEN_SWAP_ID,
+    orcaTokenSwapId,
     TOKEN_PROGRAM_ID,
     amountInU64,
     minimumAmountOutU64
@@ -93,6 +93,7 @@ export const createDepositInstruction = async (
   maximumTokenB: u64,
   tokenAPublicKey: PublicKey,
   tokenBPublicKey: PublicKey,
+  orcaTokenSwapId: PublicKey,
   owner: Owner
 ): Promise<Instruction> => {
   const depositInstruction = TokenSwap.depositAllTokenTypesInstruction(
@@ -105,7 +106,7 @@ export const createDepositInstruction = async (
     tokenBPublicKey,
     poolParams.poolTokenMint,
     userPoolTokenPublicKey,
-    ORCA_TOKEN_SWAP_ID,
+    orcaTokenSwapId,
     TOKEN_PROGRAM_ID,
     poolTokenAmount,
     maximumTokenA,
@@ -130,6 +131,7 @@ export const createWithdrawInstruction = async (
   minimumTokenB: u64,
   tokenAPublicKey: PublicKey,
   tokenBPublicKey: PublicKey,
+  orcaTokenSwapId: PublicKey,
   owner: Owner
 ): Promise<Instruction> => {
   const withdrawInstruction = TokenSwap.withdrawAllTokenTypesInstruction(
@@ -143,7 +145,7 @@ export const createWithdrawInstruction = async (
     tokenBPublicKey,
     userTokenAPublicKey,
     userTokenBPublicKey,
-    ORCA_TOKEN_SWAP_ID,
+    orcaTokenSwapId,
     TOKEN_PROGRAM_ID,
     poolTokenAmount,
     minimumTokenA,


### PR DESCRIPTION
### Changes

* Add ability to connect to devnet instances of pools and farms

### Usage

```typescript
const connection = new Connection("https://api.devnet.solana.com", "singleGossip");
const orca = getOrca(connection, Network.DEVNET);
```

One caveat to note is that there are only a few devnet pools avaialble, so if you try to access pools that are only
available on mainnet, the code will throw an error. The example code uses ORCA_SOL, which exists on the devnet.