### PR TITLE
Add pool api for getQuoteWithPoolAmounts

### DIFF
--- a/src/model/quote/quote-builder.ts
+++ b/src/model/quote/quote-builder.ts
@@ -8,6 +8,8 @@ import { StablePoolQuoteBuilder } from "./stable-quote";
 export type QuotePoolParams = PoolTokenCount & {
   inputToken: OrcaToken;
   outputToken: OrcaToken;
+  inputTokenCount: u64;
+  outputTokenCount: u64;
   feeStructure: FeeStructure;
   slippageTolerance: Percentage;
   lamportsPerSignature: number;

--- a/src/public/pools/types.ts
+++ b/src/public/pools/types.ts
@@ -1,3 +1,4 @@
+import { u64 } from "@solana/spl-token";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
 import { OrcaU64 } from "..";
@@ -63,6 +64,26 @@ export type OrcaPool = {
   getQuote: (
     inputToken: OrcaToken,
     inputAmount: Decimal | OrcaU64,
+    slippage?: Decimal
+  ) => Promise<Quote>;
+
+  /**
+   * Get the latest quote to trade on token to another in this pool using user provided pool amounts
+   *
+   * Note: slippage supports a maximum scale of 1 (ex. 0.1%). Additional decimal places will be floored.
+   *
+   * @param inputTokenId The token you want to trade from
+   * @param inputAmount The amount of token you would to trade
+   * @param inputTokenPoolAmount The amount of input tokens in the pool
+   * @param outputTokenPoolAmount The amount of output tokens in the pool
+   * @param slippage An optional slippage in percentage you are willing to take in this trade (default: 0.1%)
+   * @return Returns a quote on the exchanged token based on the input token amount
+   */
+  getQuoteWithPoolAmounts: (
+    inputToken: OrcaToken,
+    inputAmount: Decimal | OrcaU64,
+    inputTokenPoolAmount: u64,
+    outputTokenPoolAmount: u64,
     slippage?: Decimal
   ) => Promise<Quote>;
 


### PR DESCRIPTION
### Context

* Current way of getting swap quote is slow for clients because it does not cache the pool amount values (i.e. the method fetches account values everytime)

### Changes

* A new api `getQuoteWithPoolAmounts`, that takes in pool amount values as an input.