### PR TITLE
replace getRecentBlockhash with getLatestBlockhash

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@orca-so/stablecurve": "^1.0.5",
     "@solana/spl-token": "^0.1.5",
     "@solana/spl-token-swap": "^0.1.2",
-    "@solana/web3.js": "^1.24.1",
+    "@solana/web3.js": "^1.31.1",
     "decimal.js": "^10.3.1"
   },
   "devDependencies": {

--- a/src/model/orca/pool/orca-pool.ts
+++ b/src/model/orca/pool/orca-pool.ts
@@ -133,6 +133,10 @@ export class OrcaPoolImpl implements OrcaPool {
     );
     const inputAmountU64 = U64Utils.toTokenU64(inputAmount, inputPoolToken, "inputAmount");
 
+    // TODO
+    // getRecentBlockhashAndContext is deprecated
+    // it looks like fee calculation will change going forward starting v2.0
+    // we need to replace this logic once new fee calculation api becomes available
     const {
       value: { feeCalculator },
     } = await this.connection.getRecentBlockhashAndContext("singleGossip");

--- a/src/public/utils/web3/transactions/transaction-builder.ts
+++ b/src/public/utils/web3/transactions/transaction-builder.ts
@@ -31,7 +31,7 @@ export class TransactionBuilder {
   }
 
   async build(): Promise<TransactionPayload> {
-    const recentBlockHash = (await this.connection.getRecentBlockhash("singleGossip")).blockhash;
+    const recentBlockHash = (await this.connection.getLatestBlockhash("singleGossip")).blockhash;
     const txFields: TransactionCtorFields = {
       recentBlockhash: recentBlockHash,
       feePayer: this.feePayer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,6 +331,27 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ethersproject/bytes@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
+  integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
+"@ethersproject/sha2@^5.5.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -669,7 +690,7 @@
     tweetnacl "^1.0.0"
     ws "^7.0.0"
 
-"@solana/web3.js@^1.10.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.24.1":
+"@solana/web3.js@^1.10.0", "@solana/web3.js@^1.21.0":
   version "1.24.1"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.24.1.tgz#1fb29f344454669183206f452ab3b8792567cade"
   integrity sha512-XImMWAvjcXteMQwe1FFjoe6u72xmcu+UYobPIxLEMX29XXWVTalyYRKBXvcOXwz6DliTYnFXmncNEwUDEFFHGg==
@@ -702,6 +723,26 @@
     buffer "6.0.1"
     cross-fetch "^3.1.4"
     crypto-hash "^1.2.2"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
+
+"@solana/web3.js@^1.31.1":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.36.0.tgz#79d7d5217b49b80139f4de68953adc5b9a9a264f"
+  integrity sha512-RNT1451iRR7TyW7EJKMCrH/0OXawIe4zVm0DWQASwXlR/u1jmW6FrmH0lujIh7cGTlfOVbH+2ZU9AVUPLBFzwA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@ethersproject/sha2" "^5.5.0"
+    "@solana/buffer-layout" "^3.0.0"
+    bn.js "^5.0.0"
+    borsh "^0.4.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    cross-fetch "^3.1.4"
     jayson "^3.4.4"
     js-sha3 "^0.8.0"
     rpc-websockets "^7.4.2"
@@ -2268,7 +2309,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==


### PR DESCRIPTION
note: replace the deprecated getRecentBlockhash with the new getLatestBlockhash
context: https://twitter.com/GenesysGo/status/1508296004398948357