### PR TITLE
fix: minimum fee of one token

### DIFF
--- a/test/model/orca/quote/stable-quote.test.ts
+++ b/test/model/orca/quote/stable-quote.test.ts
@@ -313,4 +313,80 @@ describe("Fee Structure", () => {
       new OrcaU64(new u64("999399195675"), params.outputToken.scale)
     );
   });
+
+  test("Minimum fee of one token", () => {
+    const params = Builder<QuotePoolParams>(stableQuotePoolParams).build();
+
+    const quote = builder.buildQuote(
+      params,
+      DecimalUtil.toU64(new Decimal("0.0001"), params.inputToken.scale)
+    );
+
+    expect(quote.getRate()).toEqual(new Decimal(0.98));
+    expect(quote.getPriceImpact()).toEqual(new Decimal(-1.030928));
+    expect(quote.getLPFees()).toEqual(new OrcaU64(new u64("2"), params.inputToken.scale));
+    expect(quote.getNetworkFees()).toEqual(new OrcaU64(new u64("10000")));
+    expect(quote.getMinOutputAmount()).toEqual(
+      new OrcaU64(new u64("97"), params.outputToken.scale)
+    );
+    expect(quote.getExpectedOutputAmount()).toEqual(
+      new OrcaU64(new u64("98"), params.outputToken.scale)
+    );
+  });
+});
+
+describe("Too small inputTradeAmount", () => {
+  test("Too small inputTradeAmount (1 unit)", () => {
+    const params = Builder<QuotePoolParams>(stableQuotePoolParams).build();
+
+    const quote = builder.buildQuote(
+      params,
+      DecimalUtil.toU64(new Decimal("0.000001"), params.inputToken.scale)
+    );
+
+    expect(quote.getRate()).toEqual(new Decimal(0));
+    expect(quote.getPriceImpact()).toEqual(new Decimal(0));
+    expect(quote.getLPFees()).toEqual(new OrcaU64(new u64("2"), params.inputToken.scale));
+    expect(quote.getNetworkFees()).toEqual(new OrcaU64(new u64("10000")));
+    expect(quote.getMinOutputAmount()).toEqual(new OrcaU64(new u64("0"), params.outputToken.scale));
+    expect(quote.getExpectedOutputAmount()).toEqual(
+      new OrcaU64(new u64("0"), params.outputToken.scale)
+    );
+  });
+
+  test("Too small inputTradeAmount (2 unit)", () => {
+    const params = Builder<QuotePoolParams>(stableQuotePoolParams).build();
+
+    const quote = builder.buildQuote(
+      params,
+      DecimalUtil.toU64(new Decimal("0.000002"), params.inputToken.scale)
+    );
+
+    expect(quote.getRate()).toEqual(new Decimal(0));
+    expect(quote.getPriceImpact()).toEqual(new Decimal(0));
+    expect(quote.getLPFees()).toEqual(new OrcaU64(new u64("2"), params.inputToken.scale));
+    expect(quote.getNetworkFees()).toEqual(new OrcaU64(new u64("10000")));
+    expect(quote.getMinOutputAmount()).toEqual(new OrcaU64(new u64("0"), params.outputToken.scale));
+    expect(quote.getExpectedOutputAmount()).toEqual(
+      new OrcaU64(new u64("0"), params.outputToken.scale)
+    );
+  });
+
+  test("Too small inputTradeAmount (3 unit)", () => {
+    const params = Builder<QuotePoolParams>(stableQuotePoolParams).build();
+
+    const quote = builder.buildQuote(
+      params,
+      DecimalUtil.toU64(new Decimal("0.000003"), params.inputToken.scale)
+    );
+
+    expect(quote.getRate()).toEqual(new Decimal(0.333333));
+    expect(quote.getPriceImpact()).toEqual(new Decimal(0));
+    expect(quote.getLPFees()).toEqual(new OrcaU64(new u64("2"), params.inputToken.scale));
+    expect(quote.getNetworkFees()).toEqual(new OrcaU64(new u64("10000")));
+    expect(quote.getMinOutputAmount()).toEqual(new OrcaU64(new u64("0"), params.outputToken.scale));
+    expect(quote.getExpectedOutputAmount()).toEqual(
+      new OrcaU64(new u64("1"), params.outputToken.scale)
+    );
+  });
 });


### PR DESCRIPTION
Bug Details:
calculate_fee function of spl-token-swap includes a process to set the fee to 1 if it is truncated to 0. https://github.com/solana-labs/solana-program-library/blob/813aa3304022528cbf3cf7a3d32bca339194a492/token-swap/program/src/curve/fees.rs#L56

The SDK's fee calculation does not have this logic, so if the amount of input is small, fee calculation results in zero. As a result, on-chain, the amount of input is less than the amount of fee and the output is lower than expected.

Fixes:
- Change to the same fee calculation logic as spl-token-swap
- Added test cases to constant-product-quote.test.ts and stable-quote.test.ts

Note:
To avoid exceptions when obtaining estimates, if the fees is greater than the input, the input is treated as zero.